### PR TITLE
update service name reference

### DIFF
--- a/DOrcDeployModule.psm1
+++ b/DOrcDeployModule.psm1
@@ -906,7 +906,7 @@ function Stop-Services {
                     write-host "      Attempt to stop number:" ($i + 1)
                     Invoke-Command -ComputerName $strComputer { param($strService) Stop-Service $strService -Force} -Args $strService
                     Start-Sleep $retryTime
-                    $oService = Get-Service $strServiceNameGen -computer $strComputer
+                    $oService = Get-Service $strRemServiceName -computer $strComputer
                     $strRemServiceStatus = $oService.Status
                     if ($strRemServiceStatus -eq "Stopped") {break}
                     if ($i -eq $retryCount) {
@@ -916,7 +916,7 @@ function Stop-Services {
                         Invoke-Command -ComputerName $strComputer {param($ServicePID) Stop-Process $ServicePID -Force} -Args $ServicePID -ErrorAction SilentlyContinue
                     }
                 }
-                $oService = Get-Service $strServiceNameGen -computer $strComputer
+                $oService = Get-Service $strRemServiceName -computer $strComputer
                 $strRemServiceStatus = $oService.Status
                 if ($strRemServiceStatus -ne "Stopped") {throw "    " + $strRemServiceName + "is still" + $oService.Status}
                 else {write-host "   "$strRemServiceName "has been stopped"}


### PR DESCRIPTION
Service name in Get-service command is changed from $strServiceNameGen to $strRemServiceName to address following issue:
in case there're two services named as follows:
- Service
- Service.Other
Get-services returns two statuses simultaneously: Running Stopped when stopping first service. As a result component fails.
It happens because  $strServiceNameGen has Asterix in the end e.g. "Service*"