### PR TITLE
fix: make remote-process invocation reliable on DFS + NSIS uninstalls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,10 +73,8 @@ jobs:
         shell: pwsh
         run: |
           # Install Pester 5 (windows-latest agents ship with Pester 3) and
-          # run the focused NSIS-fix test suite. Kept narrow on purpose —
-          # the older DOrcDeployModule.tests.ps1 and DorcDeployModule.unit.tests.ps1
-          # files have not been maintained to run in CI and are excluded to
-          # avoid false failures.
+          # run every *.tests.ps1 in the repo root. Non-zero exit on failure
+          # gates the CI step.
           if (-not (Get-Module -ListAvailable Pester |
                     Where-Object { $_.Version -ge [version]'5.0.0' })) {
               Install-Module -Name Pester -MinimumVersion 5.0.0 -Force -SkipPublisherCheck -Scope CurrentUser
@@ -84,7 +82,7 @@ jobs:
           Import-Module Pester -MinimumVersion 5.0.0 -Force
 
           $cfg = New-PesterConfiguration
-          $cfg.Run.Path             = './DOrcDeployModule.nsis.tests.ps1'
+          $cfg.Run.Path             = './'
           $cfg.Run.Exit             = $true  # non-zero exit on failure — gates the CI step
           $cfg.Output.Verbosity     = 'Detailed'
           $cfg.TestResult.Enabled   = $true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,35 @@ jobs:
           pwsh ./UpdateVersion.ps1 -ProjectDir $Env:GITHUB_WORKSPACE -BuildNumber $Env:BuildNumber
         shell: pwsh
 
+      - name: Run Pester tests
+        shell: pwsh
+        run: |
+          # Install Pester 5 (windows-latest agents ship with Pester 3) and
+          # run the focused NSIS-fix test suite. Kept narrow on purpose —
+          # the older DOrcDeployModule.tests.ps1 and DorcDeployModule.unit.tests.ps1
+          # files have not been maintained to run in CI and are excluded to
+          # avoid false failures.
+          if (-not (Get-Module -ListAvailable Pester |
+                    Where-Object { $_.Version -ge [version]'5.0.0' })) {
+              Install-Module -Name Pester -MinimumVersion 5.0.0 -Force -SkipPublisherCheck -Scope CurrentUser
+          }
+          Import-Module Pester -MinimumVersion 5.0.0 -Force
+
+          $cfg = New-PesterConfiguration
+          $cfg.Run.Path             = './DOrcDeployModule.nsis.tests.ps1'
+          $cfg.Run.Exit             = $true  # non-zero exit on failure — gates the CI step
+          $cfg.Output.Verbosity     = 'Detailed'
+          $cfg.TestResult.Enabled   = $true
+          $cfg.TestResult.OutputPath = './pester-results.xml'
+          Invoke-Pester -Configuration $cfg
+
+      - name: Upload Pester test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pester-results
+          path: pester-results.xml
+
       - name: Copy updated files
         id: copy_files
         run: |

--- a/DOrcDeployModule.nsis.tests.ps1
+++ b/DOrcDeployModule.nsis.tests.ps1
@@ -1,0 +1,159 @@
+# Pester 5 tests for the NSIS-related changes in PR #13:
+#   - Find-RemoteNSIS:    strips NSIS-convention wrapping quotes from
+#                         UninstallString values; null/empty-safe.
+#   - Remove-NSISErlang:  5-attempt safety cap with explanatory throw.
+#   - Remove-NSISRabbitMQ: same cap, parallel implementation.
+
+BeforeAll {
+    $here = Split-Path -Parent $PSCommandPath
+    Import-Module "$here\DOrcDeployModule.psm1" -Force -ErrorAction Stop
+
+    # Small helper: build a fake RegistryKey tree that responds to the subset
+    # of the .NET API that Find-RemoteNSIS actually uses (GetSubKeyNames,
+    # OpenSubKey, GetValue). Lets tests bypass the real remote registry.
+    function script:New-FakeRegKey {
+        param([hashtable] $SubKeys = @{}, [hashtable] $Values = @{})
+        $obj = [PSCustomObject]@{ _SubKeys = $SubKeys; _Values = $Values }
+        $obj | Add-Member -MemberType ScriptMethod -Name 'GetSubKeyNames' -Value {
+            return @($this._SubKeys.Keys)
+        }
+        $obj | Add-Member -MemberType ScriptMethod -Name 'OpenSubKey' -Value {
+            param($name)
+            $child = $this._SubKeys[$name]
+            if ($null -eq $child) { return $null }
+            $childSubs = if ($child.ContainsKey('SubKeys')) { $child['SubKeys'] } else { @{} }
+            $childVals = if ($child.ContainsKey('Values'))  { $child['Values']  } else { @{} }
+            return (script:New-FakeRegKey -SubKeys $childSubs -Values $childVals)
+        }
+        $obj | Add-Member -MemberType ScriptMethod -Name 'GetValue' -Value {
+            param($name)
+            return $this._Values[$name]
+        }
+        return $obj
+    }
+
+    # Two canonical uninstall-key paths the real function looks at. Hoisted
+    # so the fake registry trees don't have to repeat them verbatim.
+    $script:WOW6432 = 'SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall'
+    $script:NATIVE  = 'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall'
+}
+
+Describe "Find-RemoteNSIS" {
+
+    It "Returns 'None' when no subkey contains the product string" {
+        $fake = script:New-FakeRegKey -SubKeys @{
+            $script:WOW6432 = @{ SubKeys = @{ 'Microsoft .NET' = @{ Values = @{ UninstallString = 'msiexec /X{123}' } } } }
+            $script:NATIVE  = @{ SubKeys = @{} }
+        }
+        Mock -ModuleName DOrcDeployModule Open-RemoteRegistryHive ({ return $fake }.GetNewClosure())
+
+        Find-RemoteNSIS 'server' 'Erlang' | Should -Be 'None'
+    }
+
+    It "Returns 'None' when the matching key has a null UninstallString value" {
+        # Copilot-flagged null-safety fix: without the guard, .Trim('`"')
+        # would throw a method-invocation error when GetValue returns $null.
+        $fake = script:New-FakeRegKey -SubKeys @{
+            $script:WOW6432 = @{ SubKeys = @{ 'Erlang OTP' = @{ Values = @{} } } }
+            $script:NATIVE  = @{ SubKeys = @{} }
+        }
+        Mock -ModuleName DOrcDeployModule Open-RemoteRegistryHive ({ return $fake }.GetNewClosure())
+
+        { Find-RemoteNSIS 'server' 'Erlang' } | Should -Not -Throw
+        Find-RemoteNSIS 'server' 'Erlang' | Should -Be 'None'
+    }
+
+    It "Strips the NSIS convention wrapping double-quotes from the returned UninstallString" {
+        # Registry stores '"C:\Program Files\Erlang OTP\Uninstall.exe"' with
+        # literal wrapping quotes. Callers pass this into Test-Path and
+        # ProcessStartInfo.FileName, both of which treat a leading " as part
+        # of the path — so Find-RemoteNSIS must strip them.
+        $fake = script:New-FakeRegKey -SubKeys @{
+            $script:WOW6432 = @{ SubKeys = @{
+                'Erlang OTP 26.2.5' = @{ Values = @{
+                    UninstallString = '"C:\Program Files\Erlang OTP\Uninstall.exe"'
+                }}
+            }}
+            $script:NATIVE  = @{ SubKeys = @{} }
+        }
+        Mock -ModuleName DOrcDeployModule Open-RemoteRegistryHive ({ return $fake }.GetNewClosure())
+
+        Find-RemoteNSIS 'server' 'Erlang' | Should -Be 'C:\Program Files\Erlang OTP\Uninstall.exe'
+    }
+
+    It "Returns the value unmodified when it is not wrapped in quotes" {
+        # .Trim('"') is a no-op on unquoted strings — regression guard that
+        # we aren't stripping legitimate characters.
+        $fake = script:New-FakeRegKey -SubKeys @{
+            $script:NATIVE  = @{ SubKeys = @{
+                'Erlang OTP' = @{ Values = @{ UninstallString = 'C:\X\uninst.exe' } }
+            }}
+            $script:WOW6432 = @{ SubKeys = @{} }
+        }
+        Mock -ModuleName DOrcDeployModule Open-RemoteRegistryHive ({ return $fake }.GetNewClosure())
+
+        Find-RemoteNSIS 'server' 'Erlang' | Should -Be 'C:\X\uninst.exe'
+    }
+
+    It "Finds a match in the 64-bit hive when it is not in the Wow6432 hive" {
+        $fake = script:New-FakeRegKey -SubKeys @{
+            $script:WOW6432 = @{ SubKeys = @{} }
+            $script:NATIVE  = @{ SubKeys = @{
+                'RabbitMQ Server 3.12' = @{ Values = @{
+                    UninstallString = '"C:\Program Files\RabbitMQ\Uninstall.exe"'
+                }}
+            }}
+        }
+        Mock -ModuleName DOrcDeployModule Open-RemoteRegistryHive ({ return $fake }.GetNewClosure())
+
+        Find-RemoteNSIS 'server' 'RabbitMQ' | Should -Be 'C:\Program Files\RabbitMQ\Uninstall.exe'
+    }
+}
+
+Describe "Remove-NSISErlang attempt cap" {
+
+    It "Throws after 5 attempts when the uninstaller never clears the registry entry" {
+        # Reproduces the pathology PR #13 addresses: if some future change
+        # causes Invoke-RemoteProcess to silently report success without
+        # actually uninstalling, Find-RemoteNSIS keeps reporting the product
+        # as present. The cap prevents the infinite loop that was the
+        # original hang mode.
+        Mock -ModuleName DOrcDeployModule Find-RemoteNSIS { return 'C:\Program Files\Erlang OTP\Uninstall.exe' }
+        Mock -ModuleName DOrcDeployModule Invoke-RemoteProcess { return @($true) }
+        Mock -ModuleName DOrcDeployModule Test-Path { return $false }
+
+        { Remove-NSISErlang 'server' } | Should -Throw -ExpectedMessage '*exceeded*'
+        Should -Invoke -ModuleName DOrcDeployModule -CommandName Invoke-RemoteProcess -Times 5 -Exactly
+    }
+
+    It "Exits cleanly after one successful uninstall pass" {
+        # Happy-path regression guard: if the first uninstall clears the
+        # registry entry (Find-RemoteNSIS -> 'None'), the function must NOT
+        # error out and must call Invoke-RemoteProcess exactly once.
+        $script:callCount = 0
+        Mock -ModuleName DOrcDeployModule Find-RemoteNSIS {
+            $script:callCount++
+            if ($script:callCount -eq 1) {
+                return 'C:\Program Files\Erlang OTP\Uninstall.exe'
+            }
+            return 'None'
+        }
+        Mock -ModuleName DOrcDeployModule Invoke-RemoteProcess { return @($true) }
+        Mock -ModuleName DOrcDeployModule Test-Path { return $false }
+
+        { Remove-NSISErlang 'server' } | Should -Not -Throw
+        Should -Invoke -ModuleName DOrcDeployModule -CommandName Invoke-RemoteProcess -Times 1 -Exactly
+    }
+}
+
+Describe "Remove-NSISRabbitMQ attempt cap" {
+
+    It "Throws after 5 attempts when the uninstaller never clears the registry entry" {
+        Mock -ModuleName DOrcDeployModule Find-RemoteNSIS { return 'C:\Program Files\RabbitMQ Server\Uninstall.exe' }
+        Mock -ModuleName DOrcDeployModule Invoke-RemoteProcess { return @($true) }
+        Mock -ModuleName DOrcDeployModule Test-Path { return $false }
+
+        { Remove-NSISRabbitMQ 'server' } | Should -Throw -ExpectedMessage '*exceeded*'
+        Should -Invoke -ModuleName DOrcDeployModule -CommandName Invoke-RemoteProcess -Times 5 -Exactly
+    }
+}

--- a/DOrcDeployModule.nsis.tests.ps1
+++ b/DOrcDeployModule.nsis.tests.ps1
@@ -1,16 +1,7 @@
-# Pester 5 tests for the NSIS-related changes in PR #13:
-#   - Find-RemoteNSIS:    strips NSIS-convention wrapping quotes from
-#                         UninstallString values; null/empty-safe.
-#   - Remove-NSISErlang:  5-attempt safety cap with explanatory throw.
-#   - Remove-NSISRabbitMQ: same cap, parallel implementation.
-
 BeforeAll {
     $here = Split-Path -Parent $PSCommandPath
     Import-Module "$here\DOrcDeployModule.psm1" -Force -ErrorAction Stop
 
-    # Small helper: build a fake RegistryKey tree that responds to the subset
-    # of the .NET API that Find-RemoteNSIS actually uses (GetSubKeyNames,
-    # OpenSubKey, GetValue). Lets tests bypass the real remote registry.
     function script:New-FakeRegKey {
         param([hashtable] $SubKeys = @{}, [hashtable] $Values = @{})
         $obj = [PSCustomObject]@{ _SubKeys = $SubKeys; _Values = $Values }
@@ -32,8 +23,6 @@ BeforeAll {
         return $obj
     }
 
-    # Two canonical uninstall-key paths the real function looks at. Hoisted
-    # so the fake registry trees don't have to repeat them verbatim.
     $script:WOW6432 = 'SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall'
     $script:NATIVE  = 'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall'
 }
@@ -51,8 +40,6 @@ Describe "Find-RemoteNSIS" {
     }
 
     It "Returns 'None' when the matching key has a null UninstallString value" {
-        # Copilot-flagged null-safety fix: without the guard, .Trim('`"')
-        # would throw a method-invocation error when GetValue returns $null.
         $fake = script:New-FakeRegKey -SubKeys @{
             $script:WOW6432 = @{ SubKeys = @{ 'Erlang OTP' = @{ Values = @{} } } }
             $script:NATIVE  = @{ SubKeys = @{} }
@@ -64,10 +51,6 @@ Describe "Find-RemoteNSIS" {
     }
 
     It "Strips the NSIS convention wrapping double-quotes from the returned UninstallString" {
-        # Registry stores '"C:\Program Files\Erlang OTP\Uninstall.exe"' with
-        # literal wrapping quotes. Callers pass this into Test-Path and
-        # ProcessStartInfo.FileName, both of which treat a leading " as part
-        # of the path — so Find-RemoteNSIS must strip them.
         $fake = script:New-FakeRegKey -SubKeys @{
             $script:WOW6432 = @{ SubKeys = @{
                 'Erlang OTP 26.2.5' = @{ Values = @{
@@ -82,8 +65,6 @@ Describe "Find-RemoteNSIS" {
     }
 
     It "Returns the value unmodified when it is not wrapped in quotes" {
-        # .Trim('"') is a no-op on unquoted strings — regression guard that
-        # we aren't stripping legitimate characters.
         $fake = script:New-FakeRegKey -SubKeys @{
             $script:NATIVE  = @{ SubKeys = @{
                 'Erlang OTP' = @{ Values = @{ UninstallString = 'C:\X\uninst.exe' } }
@@ -113,11 +94,6 @@ Describe "Find-RemoteNSIS" {
 Describe "Remove-NSISErlang attempt cap" {
 
     It "Throws after 5 attempts when the uninstaller never clears the registry entry" {
-        # Reproduces the pathology PR #13 addresses: if some future change
-        # causes Invoke-RemoteProcess to silently report success without
-        # actually uninstalling, Find-RemoteNSIS keeps reporting the product
-        # as present. The cap prevents the infinite loop that was the
-        # original hang mode.
         Mock -ModuleName DOrcDeployModule Find-RemoteNSIS { return 'C:\Program Files\Erlang OTP\Uninstall.exe' }
         Mock -ModuleName DOrcDeployModule Invoke-RemoteProcess { return @($true) }
         Mock -ModuleName DOrcDeployModule Test-Path { return $false }
@@ -127,9 +103,6 @@ Describe "Remove-NSISErlang attempt cap" {
     }
 
     It "Exits cleanly after one successful uninstall pass" {
-        # Happy-path regression guard: if the first uninstall clears the
-        # registry entry (Find-RemoteNSIS -> 'None'), the function must NOT
-        # error out and must call Invoke-RemoteProcess exactly once.
         $script:callCount = 0
         Mock -ModuleName DOrcDeployModule Find-RemoteNSIS {
             $script:callCount++

--- a/DOrcDeployModule.psm1
+++ b/DOrcDeployModule.psm1
@@ -2615,18 +2615,10 @@ function Invoke-RemoteProcess([string] $serverName, [string] $strExecutable, [st
 }
 
 function Open-RemoteRegistryHive([string] $serverName) {
-    # Thin wrapper around [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey
-    # to make Find-RemoteNSIS testable via Pester Mock — Pester cannot mock
-    # static .NET methods directly, so the registry access is isolated here
-    # and the logic under test just sees an injectable cmdlet.
     return [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey('LocalMachine', $serverName)
 }
 
 function Test-IsRunningAsAdministrator {
-    # Thin wrapper around the WindowsPrincipal.IsInRole(Administrator) call.
-    # Callers that require elevation (e.g. Get-DorcCredSSPStatus) should
-    # throw if this returns $false. Extracted as a cmdlet so tests can mock
-    # the result without actually elevating.
     $principal = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent())
     return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 }
@@ -2651,13 +2643,6 @@ function Find-RemoteNSIS([string] $serverName, [string] $productString) {
         }
     }
     $erlangKey, $RegKey_x32, $RegKey_x64, $Reg = $null
-    # NSIS stores UninstallString wrapped in double-quotes (per the NSIS
-    # convention for paths with spaces). Callers pass this value straight
-    # into Test-Path and ProcessStartInfo.FileName, both of which treat a
-    # leading quote as part of the literal path — so the quotes must be
-    # stripped or every uninstall attempt silently fails to find the file.
-    # Guard against a missing/empty UninstallString value (GetValue returns
-    # $null) and fall through to the "None" sentinel in that case.
     if ([string]::IsNullOrEmpty($strUninstallString)) { return "None" }
     return $strUninstallString.Trim('"')
 }
@@ -3569,13 +3554,6 @@ Function Get-DorcCredSSPStatus {
     https://blogs.technet.microsoft.com/ashleymcglone/2016/08/30/powershell-remoting-kerberos-double-hop-solved-securely/
     https://support.microsoft.com/en-gb/help/4295591/credssp-encryption-oracle-remediation-error-when-to-rdp-to-azure-vm
     #>
-    
-    
-    # Historical "#requires -RunAsAdministrator" directive removed from
-    # this location — that directive applies at script/module-import time
-    # even when indented inside a function body, which blocks importing the
-    # module for unit tests on a non-elevated CI agent. The equivalent
-    # check is enforced at call time via the IsInRole check below.
 
     [CmdletBinding()]
     param (

--- a/DOrcDeployModule.psm1
+++ b/DOrcDeployModule.psm1
@@ -2501,38 +2501,43 @@ function GetSQLServerName([string] $strInstance) {
 function Invoke-RemoteProcess([string] $serverName, [string] $strExecutable, [string] $strParams = "", [string] $strUser = "", [string] $strPassword = "", [switch]$IgnoreStdErr) {
     $bolResult = $true
     $strExecutableChild = $null
-    # Test for UNC to executable then check for user / password
-    $bolCredsOK = $false
+
+    # If the caller appended a child-process marker (e.g. NSIS ";Au_"), split
+    # it off up-front so later UNC handling sees a clean path.
+    if ($strExecutable.Contains(";")) {
+        $strExecutableChild = $strExecutable.Split(";")[1]
+        $strExecutable = $strExecutable.Split(";")[0]
+    }
+
+    # UNC inputs are staged onto the target via Copy-Item -ToSession further
+    # down. That streams bytes over the WinRM channel using the client's own
+    # identity, so the target never needs to reach back over SMB. This avoids
+    # the Windows double-hop problem (net use with explicit /user: from within
+    # a Network logon session fails with ERROR_NO_SUCH_LOGON_SESSION when the
+    # share is DFS-backed). $strUser / $strPassword are retained in the
+    # signature for backward-compatibility but are no longer consulted for UNC
+    # inputs.
+    $uncInput = $null
     if ($strExecutable.StartsWith("\\")) {
-        write-host "    UNC path has been detected, checking for username / password parameters..."
-        if ([String]::IsNullOrEmpty($strUser) -or [String]::IsNullOrEmpty($strPassword)) {
-            Write-Host "    Cannot continue as remote machine will be unable to connect out without credentials..."
-            $bolResult = $false
-        }
-        else {
-            $uncShare =  $strExecutable.SubString(0, $strExecutable.LastIndexOf("\"))
-            $strExecutable = $strExecutable.Replace($uncShare, "")
-            $uncShare = [char]34 + $uncShare + [char]34
-            write-host "    UNC Share: " $uncShare
-            write-host "    Executable:" $strExecutable
-            $bolCredsOK = $true
-        }
+        write-host "    UNC path detected - will stage on target via PSSession:" $strExecutable
+        $uncInput = $strExecutable
     }
-    else {
-        $bolCredsOK = $true
-    }
-    if ($bolCredsOK) {
-        $session = New-PSSession -ComputerName $ServerName
-        if ($strExecutable.Contains(";")) {
-            $strExecutableChild = $strExecutable.Split(";")[1]
-            $strExecutable = $strExecutable.Split(";")[0]
-        }
-        if ($strExecutable.StartsWith("\")) {
-            # Need to connect out...
-            Invoke-Command -session $session {net use * /d /y 2>&1>null}
-            Invoke-Command -session $session {net use S: $($args[0]) $($args[1]) /user:$($args[2]) 2>&1>null} -ArgumentList $uncShare, $strPassword, $strUser
-            $strExecutable = "S:" + $strExecutable
-            write-host "    Executable:" $strExecutable
+
+    $session = New-PSSession -ComputerName $ServerName
+    $stagedRemotePath = $null
+    try {
+        if ($uncInput) {
+            $stagedRemotePath = "C:\Windows\Temp\dorc-" + [guid]::NewGuid().ToString('N') + "-" + [IO.Path]::GetFileName($uncInput)
+            write-host "    Staging to target at:" $stagedRemotePath
+            try {
+                Copy-Item -ToSession $session -Path $uncInput -Destination $stagedRemotePath -Force -ErrorAction Stop
+            } catch {
+                write-host "    Copy-Item -ToSession failed:" $_.Exception.Message
+                $bolResult = $false
+                return $bolResult
+            }
+            $strExecutable = $stagedRemotePath
+            write-host "    Executable (staged):" $strExecutable
         }
         $result = Invoke-Command -session $session {$result = $false; if (Test-Path -Path $($args[0]) -PathType Leaf) { $result = $true }; return $result} -ArgumentList $strExecutable
         if ($result) {
@@ -2590,7 +2595,12 @@ function Invoke-RemoteProcess([string] $serverName, [string] $strExecutable, [st
             write-host "    Unable to find:" $strExecutable "from" $ServerName
             $bolResult = $false
         }
-        if ($strExecutable.StartsWith("\\")) {Invoke-Command -session $session {net use * /d /y 2>&1>null}}
+    } finally {
+        if ($stagedRemotePath) {
+            try {
+                Invoke-Command -session $session { Remove-Item -Path $($args[0]) -Force -ErrorAction SilentlyContinue } -ArgumentList $stagedRemotePath | Out-Null
+            } catch { }
+        }
         Remove-PSSession $session
     }
     write-host "bolResult:" $bolResult

--- a/DOrcDeployModule.psm1
+++ b/DOrcDeployModule.psm1
@@ -2588,6 +2588,7 @@ function Invoke-RemoteProcess([string] $serverName, [string] $strExecutable, [st
         }
         else {
             write-host "    Unable to find:" $strExecutable "from" $ServerName
+            $bolResult = $false
         }
         if ($strExecutable.StartsWith("\\")) {Invoke-Command -session $session {net use * /d /y 2>&1>null}}
         Remove-PSSession $session
@@ -2620,10 +2621,16 @@ function Find-RemoteNSIS([string] $serverName, [string] $productString) {
 }
 
 function Remove-NSISErlang([string] $serverName) {
-    $arrDirectories = New-Object System.Collections.ArrayList($null) 
+    $arrDirectories = New-Object System.Collections.ArrayList($null)
     $remErlang = Find-RemoteNSIS $serverName "Erlang"
+    $maxAttempts = 5
+    $attempts = 0
     do {
         if ($remErlang -ne "None") {
+            if ($attempts -ge $maxAttempts) {
+                throw "Remove-NSISErlang: exceeded $maxAttempts attempts on $serverName; uninstall string '$remErlang' still present after each attempt. The uninstall registry entry may be stale (pointing at a file that no longer exists)."
+            }
+            $attempts++
             write-host "    Uninstall string:" $remErlang
             $remErlang += ";Au_"
             $bolResult = (Invoke-RemoteProcess $serverName $remErlang "/S")[0]
@@ -2644,10 +2651,16 @@ function Remove-NSISErlang([string] $serverName) {
 }
 
 function Remove-NSISRabbitMQ([string] $serverName) {
-    $arrDirectories = New-Object System.Collections.ArrayList($null) 
+    $arrDirectories = New-Object System.Collections.ArrayList($null)
     $remRabbit = Find-RemoteNSIS $serverName "RabbitMQ"
+    $maxAttempts = 5
+    $attempts = 0
     do {
         if ($remRabbit -ne "None") {
+            if ($attempts -ge $maxAttempts) {
+                throw "Remove-NSISRabbitMQ: exceeded $maxAttempts attempts on $serverName; uninstall string '$remRabbit' still present after each attempt. The uninstall registry entry may be stale (pointing at a file that no longer exists)."
+            }
+            $attempts++
             write-host "    Uninstall string:" $remRabbit
             $remRabbit += ";Au_"
             $bolResult = (Invoke-RemoteProcess $serverName $remRabbit "/S")[0]

--- a/DOrcDeployModule.psm1
+++ b/DOrcDeployModule.psm1
@@ -2617,7 +2617,12 @@ function Find-RemoteNSIS([string] $serverName, [string] $productString) {
         }
     }
     $erlangKey, $RegKey_x32, $RegKey_x64, $Reg = $null
-    return $strUninstallString
+    # NSIS stores UninstallString wrapped in double-quotes (per the NSIS
+    # convention for paths with spaces). Callers pass this value straight
+    # into Test-Path and ProcessStartInfo.FileName, both of which treat a
+    # leading quote as part of the literal path — so the quotes must be
+    # stripped or every uninstall attempt silently fails to find the file.
+    return $strUninstallString.Trim('"')
 }
 
 function Remove-NSISErlang([string] $serverName) {

--- a/DOrcDeployModule.psm1
+++ b/DOrcDeployModule.psm1
@@ -2527,7 +2527,12 @@ function Invoke-RemoteProcess([string] $serverName, [string] $strExecutable, [st
     $stagedRemotePath = $null
     try {
         if ($uncInput) {
-            $stagedRemotePath = "C:\Windows\Temp\dorc-" + [guid]::NewGuid().ToString('N') + "-" + [IO.Path]::GetFileName($uncInput)
+            # Resolve the target's TEMP directory rather than hard-coding
+            # C:\Windows\Temp — Windows can be installed on a different drive
+            # and %TEMP% on a service account is typically what we want anyway.
+            $remoteTempDir = Invoke-Command -session $session { $env:TEMP }
+            if ([string]::IsNullOrEmpty($remoteTempDir)) { $remoteTempDir = 'C:\Windows\Temp' }
+            $stagedRemotePath = [IO.Path]::Combine($remoteTempDir, "dorc-" + [guid]::NewGuid().ToString('N') + "-" + [IO.Path]::GetFileName($uncInput))
             write-host "    Staging to target at:" $stagedRemotePath
             try {
                 Copy-Item -ToSession $session -Path $uncInput -Destination $stagedRemotePath -Force -ErrorAction Stop
@@ -2601,7 +2606,9 @@ function Invoke-RemoteProcess([string] $serverName, [string] $strExecutable, [st
                 Invoke-Command -session $session { Remove-Item -Path $($args[0]) -Force -ErrorAction SilentlyContinue } -ArgumentList $stagedRemotePath | Out-Null
             } catch { }
         }
-        Remove-PSSession $session
+        # Session teardown can throw if the session has already faulted;
+        # swallow to keep the real execution result intact.
+        try { Remove-PSSession $session -ErrorAction SilentlyContinue } catch { }
     }
     write-host "bolResult:" $bolResult
     return $bolResult
@@ -2632,6 +2639,9 @@ function Find-RemoteNSIS([string] $serverName, [string] $productString) {
     # into Test-Path and ProcessStartInfo.FileName, both of which treat a
     # leading quote as part of the literal path — so the quotes must be
     # stripped or every uninstall attempt silently fails to find the file.
+    # Guard against a missing/empty UninstallString value (GetValue returns
+    # $null) and fall through to the "None" sentinel in that case.
+    if ([string]::IsNullOrEmpty($strUninstallString)) { return "None" }
     return $strUninstallString.Trim('"')
 }
 

--- a/DOrcDeployModule.psm1
+++ b/DOrcDeployModule.psm1
@@ -2614,9 +2614,17 @@ function Invoke-RemoteProcess([string] $serverName, [string] $strExecutable, [st
     return $bolResult
 }
 
+function Open-RemoteRegistryHive([string] $serverName) {
+    # Thin wrapper around [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey
+    # to make Find-RemoteNSIS testable via Pester Mock — Pester cannot mock
+    # static .NET methods directly, so the registry access is isolated here
+    # and the logic under test just sees an injectable cmdlet.
+    return [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey('LocalMachine', $serverName)
+}
+
 function Find-RemoteNSIS([string] $serverName, [string] $productString) {
     $strUninstallString = "None"
-    $Reg = [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey('LocalMachine', $serverName)
+    $Reg = Open-RemoteRegistryHive $serverName
     $RegKey_x32 = $Reg.OpenSubKey("SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall")
     $RegKey_x64 = $Reg.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall")
     foreach ($subKeyName in $RegKey_x32.GetSubKeyNames()) {
@@ -3554,14 +3562,18 @@ Function Get-DorcCredSSPStatus {
     #>
     
     
-    #requires -RunAsAdministrator
-        
+    # Historical "#requires -RunAsAdministrator" directive removed from
+    # this location — that directive applies at script/module-import time
+    # even when indented inside a function body, which blocks importing the
+    # module for unit tests on a non-elevated CI agent. The equivalent
+    # check is enforced at call time via the IsInRole check below.
+
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
-        [String]        
+        [String]
         $ComputerName,
-        
+
         [Parameter(Mandatory = $true)]
         [pscredential]
         $Credential,
@@ -3570,7 +3582,12 @@ Function Get-DorcCredSSPStatus {
         [switch]
         $Test
     )
-    
+
+    $currentPrincipal = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent())
+    if (-not $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        throw "Get-DorcCredSSPStatus requires the session to be running as Administrator."
+    }
+
     $params = @{}
 
     if ($PSBoundParameters['ComputerName']) {

--- a/DOrcDeployModule.psm1
+++ b/DOrcDeployModule.psm1
@@ -2622,6 +2622,15 @@ function Open-RemoteRegistryHive([string] $serverName) {
     return [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey('LocalMachine', $serverName)
 }
 
+function Test-IsRunningAsAdministrator {
+    # Thin wrapper around the WindowsPrincipal.IsInRole(Administrator) call.
+    # Callers that require elevation (e.g. Get-DorcCredSSPStatus) should
+    # throw if this returns $false. Extracted as a cmdlet so tests can mock
+    # the result without actually elevating.
+    $principal = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent())
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
 function Find-RemoteNSIS([string] $serverName, [string] $productString) {
     $strUninstallString = "None"
     $Reg = Open-RemoteRegistryHive $serverName
@@ -3583,8 +3592,7 @@ Function Get-DorcCredSSPStatus {
         $Test
     )
 
-    $currentPrincipal = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent())
-    if (-not $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    if (-not (Test-IsRunningAsAdministrator)) {
         throw "Get-DorcCredSSPStatus requires the session to be running as Administrator."
     }
 

--- a/DOrcDeployModule.tests.ps1
+++ b/DOrcDeployModule.tests.ps1
@@ -12,19 +12,11 @@ Describe "Get-DorcCredSSPStatus tests" {
                     'nwtraders\administrator',
                     ('mypassword' | ConvertTo-SecureString -AsPlainText -Force))
 
-                # Bypass the admin-role guard (Get-DorcCredSSPStatus enforces
-                # it at call time; all remote operations are mocked anyway).
                 Mock -ModuleName DOrcDeployModule Test-IsRunningAsAdministrator { return $true }
 
-                # Client CredSSP enabled
                 Mock -ModuleName DOrcDeployModule Get-WSManCredSSP {
                     "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1`nThis computer is not configured to receive credentials from a remote client computer."
                 }
-                # Get-ServerOSVersion is the internal function the code actually
-                # uses for OS lookup (it wraps Get-CimInstance + a BuildNumber
-                # switch map). Mock it directly rather than trying to fake the
-                # CimInstance path — the test only cares that LocalOS/RemoteOS
-                # surface the string in the resulting object.
                 Mock -ModuleName DOrcDeployModule Get-ServerOSVersion { '10.0.17134' }
                 Mock -ModuleName DOrcDeployModule Invoke-Command {
                     "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1`nThis computer is configured to receive credentials from a remote client computer."
@@ -56,8 +48,6 @@ Describe "Get-DorcCredSSPStatus tests" {
                     'nwtraders\administrator',
                     ('mypassword' | ConvertTo-SecureString -AsPlainText -Force))
 
-                # Bypass the admin-role guard (Get-DorcCredSSPStatus enforces
-                # it at call time; all remote operations are mocked anyway).
                 Mock -ModuleName DOrcDeployModule Test-IsRunningAsAdministrator { return $true }
 
                 Mock -ModuleName DOrcDeployModule Get-WSManCredSSP {
@@ -87,8 +77,6 @@ Describe "Get-DorcCredSSPStatus tests" {
                     'nwtraders\administrator',
                     ('mypassword' | ConvertTo-SecureString -AsPlainText -Force))
 
-                # Bypass the admin-role guard (Get-DorcCredSSPStatus enforces
-                # it at call time; all remote operations are mocked anyway).
                 Mock -ModuleName DOrcDeployModule Test-IsRunningAsAdministrator { return $true }
 
                 Mock -ModuleName DOrcDeployModule Get-WSManCredSSP {
@@ -117,8 +105,6 @@ Describe "Get-DorcCredSSPStatus tests" {
                     'nwtraders\administrator',
                     ('mypassword' | ConvertTo-SecureString -AsPlainText -Force))
 
-                # Bypass the admin-role guard (Get-DorcCredSSPStatus enforces
-                # it at call time; all remote operations are mocked anyway).
                 Mock -ModuleName DOrcDeployModule Test-IsRunningAsAdministrator { return $true }
 
                 Mock -ModuleName DOrcDeployModule Get-WSManCredSSP {
@@ -147,8 +133,6 @@ Describe "Get-DorcCredSSPStatus tests" {
                     'nwtraders\administrator',
                     ('mypassword' | ConvertTo-SecureString -AsPlainText -Force))
 
-                # Bypass the admin-role guard (Get-DorcCredSSPStatus enforces
-                # it at call time; all remote operations are mocked anyway).
                 Mock -ModuleName DOrcDeployModule Test-IsRunningAsAdministrator { return $true }
 
                 Mock -ModuleName DOrcDeployModule Get-WSManCredSSP {
@@ -179,9 +163,6 @@ Describe "Get-DorcCredSSPStatus tests" {
                 ('mypassword' | ConvertTo-SecureString -AsPlainText -Force))
 
             Mock -ModuleName DOrcDeployModule Test-IsRunningAsAdministrator { return $true }
-            # Local WSMan / OS succeed, then the remote Invoke-Command (which
-            # the function uses to probe the target's WSMan state) fails —
-            # that's the path that produces the "Failed to connect..." throw.
             Mock -ModuleName DOrcDeployModule Get-WSManCredSSP {
                 "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1`nThis computer is not configured to receive credentials from a remote client computer."
             }
@@ -206,8 +187,6 @@ Describe "Enable-DorcCredSSP tests" {
                     'nwtraders\administrator',
                     ('mypassword' | ConvertTo-SecureString -AsPlainText -Force))
 
-                # Bypass the admin-role guard (Get-DorcCredSSPStatus enforces
-                # it at call time; all remote operations are mocked anyway).
                 Mock -ModuleName DOrcDeployModule Test-IsRunningAsAdministrator { return $true }
 
                 Mock -ModuleName DOrcDeployModule Get-DorcCredSSPStatus {
@@ -240,19 +219,12 @@ Describe "Enable-DorcCredSSP tests" {
                     ('mypassword' | ConvertTo-SecureString -AsPlainText -Force))
 
                 Mock -ModuleName DOrcDeployModule Test-IsRunningAsAdministrator { return $true }
-                # Enable-DorcCredSSP calls Enable-WSManCredSSP -Role Client
-                # on the local machine, which requires elevation — mock it
-                # away so the test runs on a non-elevated CI agent.
                 Mock -ModuleName DOrcDeployModule Enable-WSManCredSSP { }
 
-                # .CredSSPWorks needs to return False on the first call (before
-                # Enable-DorcCredSSP does its work) and True on the second
-                # (afterwards). A stateful counter on script scope alternates.
                 $script:mockCalled = 0
                 Mock -ModuleName DOrcDeployModule Get-DorcCredSSPStatus {
                     $script:mockCalled++
                     if ($script:mockCalled % 2 -eq 1) {
-                        # Odd run = False
                         return (New-Object psobject -Property @{
                             LocalComputerName             = $Env:COMPUTERNAME
                             RemoteComputerName            = "SERVER1"
@@ -267,7 +239,6 @@ Describe "Enable-DorcCredSSP tests" {
                             CredSSPWorks                  = "False"
                         })
                     }
-                    # Even run = True
                     return (New-Object psobject -Property @{
                         LocalComputerName             = $Env:COMPUTERNAME
                         RemoteComputerName            = "SERVER1"
@@ -282,13 +253,6 @@ Describe "Enable-DorcCredSSP tests" {
                         CredSSPWorks                  = "True"
                     })
                 }
-                # Invoke-Command is called twice: once to probe the remote
-                # machine's WSMan config (expects the "configured to receive"
-                # string), and once as the wrapper around Enable-WSManCredSSP
-                # -Role Server. The Enable path mustn't return any value —
-                # Enable-DorcCredSSP pipelines Invoke-Command's output as
-                # its return when there's no assignment, so leaking the probe
-                # string there pollutes the function's return.
                 Mock -ModuleName DOrcDeployModule Invoke-Command `
                     -ParameterFilter { $ScriptBlock -and $ScriptBlock.ToString() -match 'Enable-WSManCredSSP' } `
                     -MockWith { }  # emit nothing — real Enable-WSManCredSSP returns no output
@@ -302,9 +266,6 @@ Describe "Enable-DorcCredSSP tests" {
 
             It "Enables CredSSP successfully" {
                 $result = Enable-DorcCredSSP -ComputerName SERVER1 -Credential $script:TestCred
-                # The function prefixes the success message with "[INFO] " —
-                # the original test was written against an earlier version
-                # that didn't prefix it.
                 $result | Should -Be "[INFO] CredSSP Successfully enabled between [$Env:COMPUTERNAME] and [SERVER1]"
             }
         }
@@ -335,10 +296,6 @@ Describe "Enable-DorcCredSSP tests" {
         }
 
         It "Throws" {
-            # The function wraps the underlying Invoke-Command WinRM failure
-            # as "[ERROR] Failed to enable CredSSP on remote machine ...".
-            # Use a wildcard pattern — Pester's Should -Throw without
-            # wildcards does exact-match, not substring.
             { Enable-DorcCredSSP -ComputerName nonexistentcomputer -Credential $script:TestCred } |
                 Should -Throw '*Failed*'
         }

--- a/DOrcDeployModule.tests.ps1
+++ b/DOrcDeployModule.tests.ps1
@@ -1,23 +1,41 @@
-
-$here = Split-Path -Parent $MyInvocation.MyCommand.Path
-Import-Module "$here\DOrcDeployModule.psm1" -ErrorAction Stop
+BeforeAll {
+    $here = Split-Path -Parent $PSCommandPath
+    Import-Module "$here\DOrcDeployModule.psm1" -Force -ErrorAction Stop
+}
 
 Describe "Get-DorcCredSSPStatus tests" {
-    Context "Computer reachable"{
-        Context "Returns an object with all the expected properties"{
-            $username = "nwtraders\administrator" 
-            $password = "mypassword" | ConvertTo-SecureString -asPlainText -Force
-            $TestCred = New-Object System.Management.Automation.PSCredential($username,$password)
-            #Client CredSSP enabled
-            Mock -CommandName Get-WSManCredSSP -MockWith {return "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1`nThis computer is not configured to receive credentials from a remote client computer."}
-            #Server CredSSP enabled, Hotfix vulnerability workaround not in place, e.g. AllowEncryptionOracle value is different to 2
-            Mock -CommandName Get-WmiObject -MockWith {return (New-Object psobject -Property @{"Version"="10.0.17134"; "AllowEncryptionOracle"= 0})}
-            Mock -CommandName Invoke-Command -MockWith {return "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1
-            This computer is configured to receive credentials from a remote client computer."}
-            #Return hotfix not relevant to CredSSP vulnerability
-            Mock Get-MSHotfix {Return (New-Object psobject -Property @{"HotFixID"="KB12345678"})}
+    Context "Computer reachable" {
+
+        Context "Returns an object with all the expected properties" {
+            BeforeAll {
+                $script:TestCred = New-Object System.Management.Automation.PSCredential(
+                    'nwtraders\administrator',
+                    ('mypassword' | ConvertTo-SecureString -AsPlainText -Force))
+
+                # Bypass the admin-role guard (Get-DorcCredSSPStatus enforces
+                # it at call time; all remote operations are mocked anyway).
+                Mock -ModuleName DOrcDeployModule Test-IsRunningAsAdministrator { return $true }
+
+                # Client CredSSP enabled
+                Mock -ModuleName DOrcDeployModule Get-WSManCredSSP {
+                    "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1`nThis computer is not configured to receive credentials from a remote client computer."
+                }
+                # Get-ServerOSVersion is the internal function the code actually
+                # uses for OS lookup (it wraps Get-CimInstance + a BuildNumber
+                # switch map). Mock it directly rather than trying to fake the
+                # CimInstance path — the test only cares that LocalOS/RemoteOS
+                # surface the string in the resulting object.
+                Mock -ModuleName DOrcDeployModule Get-ServerOSVersion { '10.0.17134' }
+                Mock -ModuleName DOrcDeployModule Invoke-Command {
+                    "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1`nThis computer is configured to receive credentials from a remote client computer."
+                }
+                Mock -ModuleName DOrcDeployModule Get-MSHotfix {
+                    New-Object psobject -Property @{ HotFixID = 'KB12345678' }
+                }
+            }
+
             It "Returns an object with all the expected properties" {
-                $result = Get-DorcCredSSPStatus -ComputerName Server1 -Credential $TestCred -Test
+                $result = Get-DorcCredSSPStatus -ComputerName Server1 -Credential $script:TestCred -Test
                 $result.LocalComputerName | Should -Be $Env:COMPUTERNAME
                 $result.RemoteComputerName | Should -Be "SERVER1"
                 $result.LocalOS | Should -Be "10.0.17134"
@@ -26,197 +44,303 @@ Describe "Get-DorcCredSSPStatus tests" {
                 $result.RemoteCredSSPEnabled | Should -Match "true|false"
                 $result.LocalPatchInstalled | Should -Match "true|false"
                 $result.RemotePatchInstalled | Should -Match "true|false"
-                $result.LocalHotFixWorkaroundInPlace | Should -Match "true|false" #can be either depending on local machine it's executed on
+                $result.LocalHotFixWorkaroundInPlace | Should -Match "true|false"
                 $result.RemoteHotFixWorkaroundInPlace | Should -Match "true|false"
                 $result.CredSSPWorks | Should -Match "true|false"
             }
         }
 
-        Context "Credential Delegation Enabled on Client and on Server"{
-            $username = "nwtraders\administrator" 
-            $password = "mypassword" | ConvertTo-SecureString -asPlainText -Force
-            $TestCred = New-Object System.Management.Automation.PSCredential($username,$password)
-            #Client CredSSP enabled
-            Mock -CommandName Get-WSManCredSSP -MockWith {return "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1`nThis computer is not configured to receive credentials from a remote client computer."}
-            #Server CredSSP enabled, Hotfix vulnerability workaround not in place, e.g. AllowEncryptionOracle value is different to 2
-            Mock -CommandName Get-WmiObject -MockWith {return (New-Object psobject -Property @{"Version"="10.0.17134"; "AllowEncryptionOracle"= 0})}
-            Mock -CommandName Invoke-Command -MockWith {return "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1
-            This computer is configured to receive credentials from a remote client computer."}
-            #Return hotfix not relevant to CredSSP vulnerability
-            Mock Get-MSHotfix {Return (New-Object psobject -Property @{"HotFixID"="KB12345678"})}
-            
-            It "Returns LocalCredSSPEnabled and RemoteCredSSPEnabled as $true " {
-                $result = Get-DorcCredSSPStatus -ComputerName Server1 -Credential $TestCred
-                $result.LocalCredSSPEnabled | Should -Be $True
-                $result.RemoteCredSSPEnabled | Should -Be $True
+        Context "Credential Delegation Enabled on Client and on Server" {
+            BeforeAll {
+                $script:TestCred = New-Object System.Management.Automation.PSCredential(
+                    'nwtraders\administrator',
+                    ('mypassword' | ConvertTo-SecureString -AsPlainText -Force))
+
+                # Bypass the admin-role guard (Get-DorcCredSSPStatus enforces
+                # it at call time; all remote operations are mocked anyway).
+                Mock -ModuleName DOrcDeployModule Test-IsRunningAsAdministrator { return $true }
+
+                Mock -ModuleName DOrcDeployModule Get-WSManCredSSP {
+                    "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1`nThis computer is not configured to receive credentials from a remote client computer."
+                }
+                Mock -ModuleName DOrcDeployModule Get-WmiObject {
+                    New-Object psobject -Property @{ Version = '10.0.17134'; AllowEncryptionOracle = 0 }
+                }
+                Mock -ModuleName DOrcDeployModule Invoke-Command {
+                    "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1`nThis computer is configured to receive credentials from a remote client computer."
+                }
+                Mock -ModuleName DOrcDeployModule Get-MSHotfix {
+                    New-Object psobject -Property @{ HotFixID = 'KB12345678' }
+                }
+            }
+
+            It "Returns LocalCredSSPEnabled and RemoteCredSSPEnabled as True" {
+                $result = Get-DorcCredSSPStatus -ComputerName Server1 -Credential $script:TestCred
+                $result.LocalCredSSPEnabled | Should -Be $true
+                $result.RemoteCredSSPEnabled | Should -Be $true
             }
         }
-        Context "Credential Delegation NOT enabled on Client"{
-            $username = "nwtraders\administrator" 
-            $password = "mypassword" | ConvertTo-SecureString -asPlainText -Force
-            $TestCred = New-Object System.Management.Automation.PSCredential($username,$password)
-            #Client CredSSP enabled
-            Mock -CommandName Get-WSManCredSSP -MockWith {return "The machine is noy configured to allow delegating fresh credentials.`nThis computer is not configured to receive credentials from a remote client computer."}
-            #Server CredSSP enabled, Hotfix vulnerability workaround not in place, e.g. AllowEncryptionOracle value is different to 2
-            Mock -CommandName Get-WmiObject -MockWith {return (New-Object psobject -Property @{"Version"="10.0.17134"; "AllowEncryptionOracle"= 0})}
-            Mock -CommandName Invoke-Command -MockWith {return "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1
-            This computer is configured to receive credentials from a remote client computer."}
-            #Return hotfix not relevant to CredSSP vulnerability
-            Mock -CommandName Get-MSHotfix -MockWith {Return (New-Object psobject -Property @{"HotFixID"="KB12345678"})}
-            
-            It "Returns LocalCredSSPEnabled as $false" {
-                $result = Get-DorcCredSSPStatus -ComputerName Server1 -Credential $TestCred
+
+        Context "Credential Delegation NOT enabled on Client" {
+            BeforeAll {
+                $script:TestCred = New-Object System.Management.Automation.PSCredential(
+                    'nwtraders\administrator',
+                    ('mypassword' | ConvertTo-SecureString -AsPlainText -Force))
+
+                # Bypass the admin-role guard (Get-DorcCredSSPStatus enforces
+                # it at call time; all remote operations are mocked anyway).
+                Mock -ModuleName DOrcDeployModule Test-IsRunningAsAdministrator { return $true }
+
+                Mock -ModuleName DOrcDeployModule Get-WSManCredSSP {
+                    "The machine is not configured to allow delegating fresh credentials.`nThis computer is not configured to receive credentials from a remote client computer."
+                }
+                Mock -ModuleName DOrcDeployModule Get-WmiObject {
+                    New-Object psobject -Property @{ Version = '10.0.17134'; AllowEncryptionOracle = 0 }
+                }
+                Mock -ModuleName DOrcDeployModule Invoke-Command {
+                    "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1`nThis computer is configured to receive credentials from a remote client computer."
+                }
+                Mock -ModuleName DOrcDeployModule Get-MSHotfix {
+                    New-Object psobject -Property @{ HotFixID = 'KB12345678' }
+                }
+            }
+
+            It "Returns LocalCredSSPEnabled as False" {
+                $result = Get-DorcCredSSPStatus -ComputerName Server1 -Credential $script:TestCred
                 $result.LocalCredSSPEnabled | Should -Be $false
             }
         }
 
-        Context "Credential Delegation enabled on Client but delegated computer doesn't match remote computer's name"{
-            $username = "nwtraders\administrator" 
-            $password = "mypassword" | ConvertTo-SecureString -asPlainText -Force
-            $TestCred = New-Object System.Management.Automation.PSCredential($username,$password)
-            #Client CredSSP enabled
-            Mock -CommandName Get-WSManCredSSP -MockWith {return "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER2`nThis computer is not configured to receive credentials from a remote client computer."}
-            #Server CredSSP enabled, Hotfix vulnerability workaround not in place, e.g. AllowEncryptionOracle value is different to 2
-            Mock -CommandName Get-WmiObject -MockWith {return (New-Object psobject -Property @{"Version"="10.0.17134"; "AllowEncryptionOracle"= 0})}
-            Mock -CommandName Invoke-Command -MockWith {return "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1
-            This computer is configured to receive credentials from a remote client computer."}
-            #Return hotfix not relevant to CredSSP vulnerability
-            Mock -CommandName Get-MSHotfix -MockWith {Return (New-Object psobject -Property @{"HotFixID"="KB12345678"})}
-            
-            It "Returns LocalCredSSPEnabled as $false" {
-                $result = Get-DorcCredSSPStatus -ComputerName Server1 -Credential $TestCred
+        Context "Credential Delegation enabled on Client but delegated computer doesn't match remote computer's name" {
+            BeforeAll {
+                $script:TestCred = New-Object System.Management.Automation.PSCredential(
+                    'nwtraders\administrator',
+                    ('mypassword' | ConvertTo-SecureString -AsPlainText -Force))
+
+                # Bypass the admin-role guard (Get-DorcCredSSPStatus enforces
+                # it at call time; all remote operations are mocked anyway).
+                Mock -ModuleName DOrcDeployModule Test-IsRunningAsAdministrator { return $true }
+
+                Mock -ModuleName DOrcDeployModule Get-WSManCredSSP {
+                    "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER2`nThis computer is not configured to receive credentials from a remote client computer."
+                }
+                Mock -ModuleName DOrcDeployModule Get-WmiObject {
+                    New-Object psobject -Property @{ Version = '10.0.17134'; AllowEncryptionOracle = 0 }
+                }
+                Mock -ModuleName DOrcDeployModule Invoke-Command {
+                    "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1`nThis computer is configured to receive credentials from a remote client computer."
+                }
+                Mock -ModuleName DOrcDeployModule Get-MSHotfix {
+                    New-Object psobject -Property @{ HotFixID = 'KB12345678' }
+                }
+            }
+
+            It "Returns LocalCredSSPEnabled as False (delegated computer mismatch)" {
+                $result = Get-DorcCredSSPStatus -ComputerName Server1 -Credential $script:TestCred
                 $result.LocalCredSSPEnabled | Should -Be $false
             }
         }
-        Context "Credential Delegation not enabled on Server"{
-            $username = "nwtraders\administrator" 
-            $password = "mypassword" | ConvertTo-SecureString -asPlainText -Force
-            $TestCred = New-Object System.Management.Automation.PSCredential($username,$password)
-            #Client CredSSP enabled
-            Mock -CommandName Get-WSManCredSSP -MockWith {return "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1`nThis computer is not configured to receive credentials from a remote client computer."}
-            #Server CredSSP enabled, Hotfix vulnerability workaround not in place, e.g. AllowEncryptionOracle value is different to 2
-            Mock -CommandName  Get-WmiObject -MockWith {return (New-Object psobject -Property @{"Version"="10.0.17134"; "AllowEncryptionOracle"= 0})}
-            Mock -CommandName Invoke-Command -MockWith {return "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1`nThis computer is not configured to receive credentials from a remote client computer."}
-            #Return hotfix not relevant to CredSSP vulnerability
-            Mock -CommandName Get-MSHotfix -MockWith {Return (New-Object psobject -Property @{"HotFixID"="KB12345678"})}
-            
-            It "Returns an object with all the expected properties" {
-                $result = Get-DorcCredSSPStatus -ComputerName Server1 -Credential $TestCred
+
+        Context "Credential Delegation not enabled on Server" {
+            BeforeAll {
+                $script:TestCred = New-Object System.Management.Automation.PSCredential(
+                    'nwtraders\administrator',
+                    ('mypassword' | ConvertTo-SecureString -AsPlainText -Force))
+
+                # Bypass the admin-role guard (Get-DorcCredSSPStatus enforces
+                # it at call time; all remote operations are mocked anyway).
+                Mock -ModuleName DOrcDeployModule Test-IsRunningAsAdministrator { return $true }
+
+                Mock -ModuleName DOrcDeployModule Get-WSManCredSSP {
+                    "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1`nThis computer is not configured to receive credentials from a remote client computer."
+                }
+                Mock -ModuleName DOrcDeployModule Get-WmiObject {
+                    New-Object psobject -Property @{ Version = '10.0.17134'; AllowEncryptionOracle = 0 }
+                }
+                Mock -ModuleName DOrcDeployModule Invoke-Command {
+                    "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1`nThis computer is not configured to receive credentials from a remote client computer."
+                }
+                Mock -ModuleName DOrcDeployModule Get-MSHotfix {
+                    New-Object psobject -Property @{ HotFixID = 'KB12345678' }
+                }
+            }
+
+            It "Returns RemoteCredSSPEnabled as False" {
+                $result = Get-DorcCredSSPStatus -ComputerName Server1 -Credential $script:TestCred
                 $result.RemoteCredSSPEnabled | Should -Be $false
             }
         }
     }
-    Context "Computer not reachable"{ 
-        $username = "nwtraders\administrator" 
-        $password = "mypassword" | ConvertTo-SecureString -asPlainText -Force
-        $TestCred = New-Object System.Management.Automation.PSCredential($username,$password)
-        Mock -CommandName Get-WmiObject -MockWith {return (New-Object psobject -Property @{"Version"="10.0.17134"; "AllowEncryptionOracle"= 0})}
+
+    Context "Computer not reachable" {
+        BeforeAll {
+            $script:TestCred = New-Object System.Management.Automation.PSCredential(
+                'nwtraders\administrator',
+                ('mypassword' | ConvertTo-SecureString -AsPlainText -Force))
+
+            Mock -ModuleName DOrcDeployModule Test-IsRunningAsAdministrator { return $true }
+            # Local WSMan / OS succeed, then the remote Invoke-Command (which
+            # the function uses to probe the target's WSMan state) fails —
+            # that's the path that produces the "Failed to connect..." throw.
+            Mock -ModuleName DOrcDeployModule Get-WSManCredSSP {
+                "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1`nThis computer is not configured to receive credentials from a remote client computer."
+            }
+            Mock -ModuleName DOrcDeployModule Get-ServerOSVersion { '10.0.17134' }
+            Mock -ModuleName DOrcDeployModule Invoke-Command {
+                throw [System.Management.Automation.RemoteException]::new('Connection refused')
+            }
+        }
+
         It "Fails" {
-            {Get-DorcCredSSPStatus -ComputerName Server1 -Credential $TestCred} | should -Throw "Failed to connect"
+            { Get-DorcCredSSPStatus -ComputerName Server1 -Credential $script:TestCred } | Should -Throw "*Failed to connect*"
         }
     }
 }
 
 Describe "Enable-DorcCredSSP tests" {
     Context "Computer reachable" {
+
         Context "Already enabled" {
-            $username = "nwtraders\administrator" 
-            $password = "mypassword" | ConvertTo-SecureString -asPlainText -Force
-            $TestCred = New-Object System.Management.Automation.PSCredential($username,$password)
-            Mock -CommandName Get-DorcCredSSPStatus -MockWith {return ((New-Object psobject -Property `
-                @{
-                    "LocalComputerName"             = $Env:COMPUTERNAME
-                    "RemoteComputerName"            = "SERVER1"
-                    "LocalOS"                       = "10.0.17134"
-                    "RemoteOS"                      = "10.0.14393"
-                    "LocalCredSSPEnabled"           = "True"
-                    "RemoteCredSSPEnabled"          = "True"
-                    "LocalPatchInstalled"           = "False"
-                    "RemotePatchInstalled"          = "False"
-                    "LocalHotFixWorkaroundInPlace"  = "False"
-                    "RemoteHotFixWorkaroundInPlace" = "False"
-                    "CredSSPWorks"                  = "True"
-                }))}
-            It "Nothing to do" {
-                $result = Enable-DorcCredSSP -ComputerName SERVER1 -Credential $TestCred
-                $result | Should -Be "[INFO] CredSSP has already been enabled between [$Env:COMPUTERNAME] and [SERVER1]"
+            BeforeAll {
+                $script:TestCred = New-Object System.Management.Automation.PSCredential(
+                    'nwtraders\administrator',
+                    ('mypassword' | ConvertTo-SecureString -AsPlainText -Force))
+
+                # Bypass the admin-role guard (Get-DorcCredSSPStatus enforces
+                # it at call time; all remote operations are mocked anyway).
+                Mock -ModuleName DOrcDeployModule Test-IsRunningAsAdministrator { return $true }
+
+                Mock -ModuleName DOrcDeployModule Get-DorcCredSSPStatus {
+                    New-Object psobject -Property @{
+                        LocalComputerName             = $Env:COMPUTERNAME
+                        RemoteComputerName            = "SERVER1"
+                        LocalOS                       = "10.0.17134"
+                        RemoteOS                      = "10.0.14393"
+                        LocalCredSSPEnabled           = "True"
+                        RemoteCredSSPEnabled          = "True"
+                        LocalPatchInstalled           = "False"
+                        RemotePatchInstalled          = "False"
+                        LocalHotFixWorkaroundInPlace  = "False"
+                        RemoteHotFixWorkaroundInPlace = "False"
+                        CredSSPWorks                  = "True"
+                    }
+                }
             }
 
+            It "Nothing to do" {
+                $result = Enable-DorcCredSSP -ComputerName SERVER1 -Credential $script:TestCred
+                $result | Should -Be "[INFO] CredSSP has already been enabled between [$Env:COMPUTERNAME] and [SERVER1]"
+            }
         }
-        Context "Not yet enabled" {
-            Context "Return $false and then $true for CredSSPWorks property with each execution of Get-DorcCredSSPStatus"{
-                $username = "nwtraders\administrator" 
-                $password = "mypassword" | ConvertTo-SecureString -asPlainText -Force
-                $TestCred = New-Object System.Management.Automation.PSCredential($username,$password)
-                #.CredSSPWorks needs to first return $false and then $true. This little loop allows for this.
+
+        Context "Not yet enabled - Get-DorcCredSSPStatus returns False then True across successive calls" {
+            BeforeAll {
+                $script:TestCred = New-Object System.Management.Automation.PSCredential(
+                    'nwtraders\administrator',
+                    ('mypassword' | ConvertTo-SecureString -AsPlainText -Force))
+
+                Mock -ModuleName DOrcDeployModule Test-IsRunningAsAdministrator { return $true }
+                # Enable-DorcCredSSP calls Enable-WSManCredSSP -Role Client
+                # on the local machine, which requires elevation — mock it
+                # away so the test runs on a non-elevated CI agent.
+                Mock -ModuleName DOrcDeployModule Enable-WSManCredSSP { }
+
+                # .CredSSPWorks needs to return False on the first call (before
+                # Enable-DorcCredSSP does its work) and True on the second
+                # (afterwards). A stateful counter on script scope alternates.
                 $script:mockCalled = 0
-                $MockDorcCredSSPStatus = {
+                Mock -ModuleName DOrcDeployModule Get-DorcCredSSPStatus {
                     $script:mockCalled++
-                    if ($script:mockCalled %2 -eq 1) { #each odd run is $false 
-                        return ((New-Object psobject -Property `
-                            @{
-                                "LocalComputerName"             = $Env:COMPUTERNAME
-                                "RemoteComputerName"            = "SERVER1"
-                                "LocalOS"                       = "10.0.17134"
-                                "RemoteOS"                      = "10.0.14393"
-                                "LocalCredSSPEnabled"           = "False"
-                                "RemoteCredSSPEnabled"          = "False"
-                                "LocalPatchInstalled"           = "False"
-                                "RemotePatchInstalled"          = "False"
-                                "LocalHotFixWorkaroundInPlace"  = "False"
-                                "RemoteHotFixWorkaroundInPlace" = "False"
-                                "CredSSPWorks"                  = "False"
-                            }))
+                    if ($script:mockCalled % 2 -eq 1) {
+                        # Odd run = False
+                        return (New-Object psobject -Property @{
+                            LocalComputerName             = $Env:COMPUTERNAME
+                            RemoteComputerName            = "SERVER1"
+                            LocalOS                       = "10.0.17134"
+                            RemoteOS                      = "10.0.14393"
+                            LocalCredSSPEnabled           = "False"
+                            RemoteCredSSPEnabled          = "False"
+                            LocalPatchInstalled           = "False"
+                            RemotePatchInstalled          = "False"
+                            LocalHotFixWorkaroundInPlace  = "False"
+                            RemoteHotFixWorkaroundInPlace = "False"
+                            CredSSPWorks                  = "False"
+                        })
                     }
-                    else {
-                        return ((New-Object psobject -Property `
-                            @{
-                                "LocalComputerName"             = $Env:COMPUTERNAME
-                                "RemoteComputerName"            = "SERVER1"
-                                "LocalOS"                       = "10.0.17134"
-                                "RemoteOS"                      = "10.0.14393"
-                                "LocalCredSSPEnabled"           = "True"
-                                "RemoteCredSSPEnabled"          = "True"
-                                "LocalPatchInstalled"           = "True"
-                                "RemotePatchInstalled"          = "True"
-                                "LocalHotFixWorkaroundInPlace"  = "True"
-                                "RemoteHotFixWorkaroundInPlace" = "True"
-                                "CredSSPWorks"                  = "True"
-                            }))
-                    }
-                    
+                    # Even run = True
+                    return (New-Object psobject -Property @{
+                        LocalComputerName             = $Env:COMPUTERNAME
+                        RemoteComputerName            = "SERVER1"
+                        LocalOS                       = "10.0.17134"
+                        RemoteOS                      = "10.0.14393"
+                        LocalCredSSPEnabled           = "True"
+                        RemoteCredSSPEnabled          = "True"
+                        LocalPatchInstalled           = "True"
+                        RemotePatchInstalled          = "True"
+                        LocalHotFixWorkaroundInPlace  = "True"
+                        RemoteHotFixWorkaroundInPlace = "True"
+                        CredSSPWorks                  = "True"
+                    })
                 }
-                Mock -CommandName Invoke-Command -MockWith {return "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1
-                This computer is configured to receive credentials from a remote client computer."}
-                Mock -CommandName Get-DorcCredSSPStatus -MockWith $MockDorcCredSSPStatus
-                Mock -CommandName Get-MSHotfix -MockWith {Return (New-Object psobject -Property @{"HotFixID"="KB12345678"})}
-                It "Enables CredSSP successfully" {
-                    $result = Enable-DorcCredSSP -ComputerName SERVER1 -Credential $TestCred
-                    $result | Should -Be "CredSSP Successfully enabled between [$ENV:ComputerName] and [SERVER1]"
+                # Invoke-Command is called twice: once to probe the remote
+                # machine's WSMan config (expects the "configured to receive"
+                # string), and once as the wrapper around Enable-WSManCredSSP
+                # -Role Server. The Enable path mustn't return any value —
+                # Enable-DorcCredSSP pipelines Invoke-Command's output as
+                # its return when there's no assignment, so leaking the probe
+                # string there pollutes the function's return.
+                Mock -ModuleName DOrcDeployModule Invoke-Command `
+                    -ParameterFilter { $ScriptBlock -and $ScriptBlock.ToString() -match 'Enable-WSManCredSSP' } `
+                    -MockWith { }  # emit nothing — real Enable-WSManCredSSP returns no output
+                Mock -ModuleName DOrcDeployModule Invoke-Command {
+                    "The machine is configured to allow delegating fresh credentials to the following target(s): SERVER1`nThis computer is configured to receive credentials from a remote client computer."
                 }
+                Mock -ModuleName DOrcDeployModule Get-MSHotfix {
+                    New-Object psobject -Property @{ HotFixID = 'KB12345678' }
+                }
+            }
+
+            It "Enables CredSSP successfully" {
+                $result = Enable-DorcCredSSP -ComputerName SERVER1 -Credential $script:TestCred
+                # The function prefixes the success message with "[INFO] " —
+                # the original test was written against an earlier version
+                # that didn't prefix it.
+                $result | Should -Be "[INFO] CredSSP Successfully enabled between [$Env:COMPUTERNAME] and [SERVER1]"
             }
         }
     }
+
     Context "Computer not reachable" {
-        $username = "nwtraders\administrator" 
-        $password = "mypassword" | ConvertTo-SecureString -asPlainText -Force
-        $TestCred = New-Object System.Management.Automation.PSCredential($username,$password)
-        Mock Get-DorcCredSSPStatus {return ((New-Object psobject -Property `
-            @{
-                "LocalComputerName"             = $Env:COMPUTERNAME
-                "RemoteComputerName"            = "SERVER1"
-                "LocalOS"                       = "10.0.17134"
-                "RemoteOS"                      = "10.0.14393"
-                "LocalCredSSPEnabled"           = "True"
-                "RemoteCredSSPEnabled"          = "False"
-                "LocalPatchInstalled"           = "False"
-                "RemotePatchInstalled"          = "False"
-                "LocalHotFixWorkaroundInPlace"  = "False"
-                "RemoteHotFixWorkaroundInPlace" = "False"
-                "CredSSPWorks"                  = "False"
-            }))}
+        BeforeAll {
+            $script:TestCred = New-Object System.Management.Automation.PSCredential(
+                'nwtraders\administrator',
+                ('mypassword' | ConvertTo-SecureString -AsPlainText -Force))
+
+            Mock -ModuleName DOrcDeployModule Test-IsRunningAsAdministrator { return $true }
+            Mock -ModuleName DOrcDeployModule Get-DorcCredSSPStatus {
+                New-Object psobject -Property @{
+                    LocalComputerName             = $Env:COMPUTERNAME
+                    RemoteComputerName            = "SERVER1"
+                    LocalOS                       = "10.0.17134"
+                    RemoteOS                      = "10.0.14393"
+                    LocalCredSSPEnabled           = "True"
+                    RemoteCredSSPEnabled          = "False"
+                    LocalPatchInstalled           = "False"
+                    RemotePatchInstalled          = "False"
+                    LocalHotFixWorkaroundInPlace  = "False"
+                    RemoteHotFixWorkaroundInPlace = "False"
+                    CredSSPWorks                  = "False"
+                }
+            }
+        }
+
         It "Throws" {
-            {Enable-DorcCredSSP -ComputerName nonexistentcomputer -Credential $TestCred } | Should -Throw 'Failed'
+            # The function wraps the underlying Invoke-Command WinRM failure
+            # as "[ERROR] Failed to enable CredSSP on remote machine ...".
+            # Use a wildcard pattern — Pester's Should -Throw without
+            # wildcards does exact-match, not substring.
+            { Enable-DorcCredSSP -ComputerName nonexistentcomputer -Credential $script:TestCred } |
+                Should -Throw '*Failed*'
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes four distinct, layered bugs in `Invoke-RemoteProcess` / `Find-RemoteNSIS` / `Remove-NSIS{Erlang,RabbitMQ}` that together caused RabbitMQ/Erlang deploys to hang indefinitely or fail silently against DFS-backed artifact shares (e.g. `\\Itss.global\…`). Verified end-to-end against a real non-prod DOrc env: the same `010 Install Erlang → 020 Install RabbitMQ → 030 Configure RabbitMQ` sequence that previously hung for 3+ minutes / aborted after 1 second now completes in under 2 minutes with all installers actually running on the target.

## The four bugs, in order of discovery

### 1. `Invoke-RemoteProcess` returned `$true` even when `Test-Path` on the target couldn't find the executable

When `Test-Path -Path $strExecutable -PathType Leaf` returned `$false`, the `else` branch logged `"Unable to find: ..."` but **never flipped `$bolResult` to `$false`**. Callers saw the return as `$true` and assumed the work was done. Combined with bug #3, this turned failures into silent infinite loops.

### 2. `Remove-NSIS{Erlang,RabbitMQ}` had an unbounded `do { } while ($rem -ne "None")` loop

Both functions loop until `Find-RemoteNSIS` says the uninstall-registry entry is gone. With bug #1 faking success, the registry entry never disappeared, so the loop ran ~330 iterations over 3 min 20 s before the deploy was manually cancelled — producing thousands of identical `Unable to find` / `Result: True` log lines with zero forward progress.

### 3. `Find-RemoteNSIS` returned the raw `UninstallString` including NSIS's mandatory wrapping quotes

NSIS stores `UninstallString` as e.g. the literal 43-character value `"C:\Program Files\Erlang OTP\Uninstall.exe"` — quotes are part of the value, so the path round-trips through shell invocation. `Find-RemoteNSIS` returned this verbatim. Downstream, `Invoke-RemoteProcess` passed it straight into `Test-Path`, which treats the leading `"` as part of a literal path and returns `$false` on every pass — making it look like the uninstaller file was missing even when it was genuinely on disk.

Proof (recorded live against a running target):
```
Registry value length: 43
Test-Path on raw value : False
Test-Path on trimmed   : True
```

This was the actual **root cause** of bug #2's infinite loops — every `Invoke-RemoteProcess` call was guaranteed to fail `Test-Path` for NSIS-style uninstaller paths, and bug #1 silently turned that into fake success.

### 4. `net use S: <unc> /user:<creds>` fails with `ERROR_NO_SUCH_LOGON_SESSION (1312)` inside a PSSession when the share is DFS-backed

The UNC handling inside `Invoke-RemoteProcess` opened a PSSession to the target, then ran `net use S: "<unc>" <password> /user:<user>` *inside* that session to map the artifact share. That is the classic Windows double-hop:

- The PSSession is a Type 3 Network logon on the target (hop #1).
- Any `/user:` + `net use` from inside it calls `LsaLogonUser` to create new credentials, which requires a logon type the Network session cannot provide.
- When the share is DFS-backed (domain-based DFS namespace like `\\Itss.global\prod\...`), the DFS referral adds a *second* authentication step. `LsaLogonUser` fails with 1312 before credentials are ever evaluated against the share's ACL.

The old AzDO drop location worked because it was a **direct-server share** (`\\tfsbdev01lonuk\drops\...`) — single auth exchange, no DFS referral. The new GitHub-sourced artifact path is on a Domain V2 DFS namespace, which exposes the long-latent double-hop bug. The `2>&1>null` on the `net use` call was suppressing the real error, which made this invisible for years.

```
net use S: output: exitcode=2
  System error 1312 has occurred.
  A specified logon session does not exist. It may already have been terminated.
```

## The fix — three commits

### Commit 1 — `Invoke-RemoteProcess` fail-closed + bounded NSIS retries

- `Invoke-RemoteProcess`: set `$bolResult = $false` in the `else` branch when the `Test-Path` check for the executable fails, so callers observe the real outcome.
- `Remove-NSISErlang` / `Remove-NSISRabbitMQ`: add a 5-attempt safety cap around the `do { } while` loop, with an explanatory `throw` that points operators at stale registry entries as a likely cause. Defence in depth if any future code path ever silently returns `$true`.

### Commit 2 — `Find-RemoteNSIS` normalises the NSIS quoting

`.Trim('"')` at the single return point. Callers that compare against the `"None"` sentinel still work (no embedded quotes in that string), and `Test-Path` / `ProcessStartInfo.FileName` both now receive a clean filesystem path. No external callers — `Find-RemoteNSIS` is only used by the two `Remove-NSIS*` functions.

### Commit 3 — `Invoke-RemoteProcess` stages UNC artifacts via `Copy-Item -ToSession`

Replaces the `net use` dance entirely:

- Detect UNC input.
- Open the PSSession as before.
- `Copy-Item -ToSession $session -Path $uncInput -Destination "C:\Windows\Temp\dorc-<guid>-<filename>"` — runs on the **client** side (the caller), so the UNC is read using the caller's own identity over the existing WinRM channel. The target never makes an outbound SMB call, so DFS referral / double-hop doesn't apply.
- Run the binary from the target-local path.
- Clean up the staged file in a `finally` block so mid-flight failures don't leak temp files.

`$strUser` / `$strPassword` parameters kept in the signature for backward compatibility with existing callers, but no longer consulted for UNC inputs. The `;Au_` child-process split is moved to the top of the function so UNC paths that ever carry that NSIS suffix (unusual, but possible) are handled correctly.

### Backward compatibility for all existing callers

`Invoke-RemoteProcess` is called in four places in the module:

| Caller | Path type | Behaviour change |
|---|---|---|
| `Remove-NSISErlang` (L2651) | Local target path (e.g. `C:\...\Uninstall.exe;Au_`) | None — doesn't start with `\\`, skips the new Copy-Item branch |
| `Remove-NSISRabbitMQ` (L2681) | Same pattern | None |
| `UnRegister-FromGAC` (L3977) | Whatever `$GACUtilPath` is — typically a local target path | None for local; UNC inputs now stage transparently |
| `Register-ToGAC` (L3996) | Same | None |

No existing caller's behaviour changes for non-UNC inputs. UNC inputs now work for DFS-backed shares that previously failed.

## Evidence (six consecutive deploys against the same target)

Real non-prod DOrc environment, same GitHub-sourced RabbitMQ project, same target `GMXX-DORAPP01`:

| Request | State of the fix | Outcome |
|---|---|---|
| 1863974 | No fixes | **Hung** 3m20s in `Remove-NSISErlang` loop (~330 iterations), manual cancel |
| 1863975 | Commit 1 | Fail-fast on first missing-file attempt after ~1s; Erlang uninstall itself still failed because of bug #3 |
| 1863976 | Commits 1+2, artifact on monitor-local temp | Erlang **uninstalled successfully** for first time; install failed because the monitor-local path was not reachable from the target |
| 1863977 | Commits 1+2, artifact on DFS UNC | Surfaced error 1312; diagnostic instrumentation confirmed DFS + double-hop as the root cause |
| 1863978 | Commits 1+2, diagnostic for direct-UNC read | Proved `Test-Path` from PSSession as `svc-live-deploy-nonp` gets `UnauthorizedAccessException` against the DFS path — double-hop, not an ACL issue |
| 1863979 | All three commits | **Success** through scripts 005 → 010 → 020 → 030. Script 040 failed for an unrelated DOrc env-config issue (`No settings for plugin rabbitmq_consistent_hash_exchange`) with no module involvement. |

Selected evidence from 1863979's `010 - Install Erlang Binaries.ps1`:

```
16:48:13  UNC path detected - will stage on target via PSSession:
              \\Itss.global\...\DORC DV 03\...\drop\Server\otp_win64_27.3.4.1.exe
16:48:13  Staging to target at: C:\Windows\Temp\dorc-89231e98...-otp_win64_27.3.4.1.exe
16:48:33  Executable (staged): C:\Windows\Temp\dorc-89231e98...-otp_win64_27.3.4.1.exe     (~20s to stream ~164MB over WinRM)
16:49:12  Remote execution complete, exit code: 0
16:49:12  Execution of 010 - Install Erlang Binaries.ps1 was successful
```

## Automated coverage

Added `DOrcDeployModule.nsis.tests.ps1` with 8 Pester 5 tests and wired the CI workflow to run them on every build:

- `Find-RemoteNSIS` — 5 tests: "None" sentinel when no match; "None" when the matched key has no `UninstallString` value (the Copilot null-safety fix from an earlier review round); quote stripping for NSIS-convention values; untrimmed passthrough for unquoted values; lookup in the 64-bit hive when Wow6432 is empty.
- `Remove-NSISErlang` — 2 tests: 5-attempt safety cap throws with `exceeded` when the registry entry never clears; happy path exits cleanly after one successful uninstall pass with exactly one `Invoke-RemoteProcess` call.
- `Remove-NSISRabbitMQ` — 1 test mirroring the 5-attempt cap.

Made the untestable static .NET call in `Find-RemoteNSIS` mockable by extracting `[Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey` into a thin cmdlet wrapper (`Open-RemoteRegistryHive`) — Pester can't mock .NET static methods, so isolating the registry access at a cmdlet boundary lets the tests inject a fake registry tree without live remote-registry access.

Also removed an indented `#requires -RunAsAdministrator` directive inside `Get-DorcCredSSPStatus` — that directive is parsed at module-import time even when indented inside a function body, which blocked `Import-Module` on a non-elevated CI agent. Replaced with an explicit `WindowsPrincipal.IsInRole(Administrator)` check at call time (identical user-facing behaviour; no longer blocks `Import-Module`).

CI results on the most recent run: `Tests Passed: 8, Failed: 0`. Full Pester XML results uploaded as a build artifact (`pester-results`).

## Test plan

- [x] **Automated**: CI runs 8 Pester 5 tests on every build (see "Automated coverage" above). Green on this branch.
- [ ] **Happy path — local target paths (NSIS uninstaller from registry)**: run any RabbitMQ/Erlang deploy. `Remove-NSIS{Erlang,RabbitMQ}` should run once, uninstaller should execute, registry entry should disappear. Regression check for commits 1 + 2.
- [ ] **Happy path — UNC artifact inputs**: run a GitHub-sourced RabbitMQ deploy. Expect `UNC path detected - will stage on target via PSSession` + `Staging to target at: ...` + `Remote execution complete, exit code: 0`. Should work identically against DFS-backed and direct-server UNC shares.
- [ ] **Stale registry entry (uninstaller file missing)**: manually create a bogus `HKLM\SOFTWARE\...\Uninstall\{TestProduct}` key with `UninstallString` pointing at a non-existent file, then trigger `Find-RemoteNSIS` + `Remove-NSISErlang`-style logic against it. Expect fail-fast on first attempt with the existing `"Failed to remove..."` throw — no looping.
- [ ] **5-attempt cap**: hard to reproduce without forging a return-True scenario. Confirm the new `throw` text mentions stale registry entries so future operators get a useful hint.
- [ ] **Copy-Item staging failure**: simulate an unreachable UNC (e.g. typo in the configured download folder). Expect the `catch` to return `$false` immediately, `finally` to still run cleanup (no-op in that case), and the caller to see a clean failure.
- [ ] **Staged file cleanup**: after a successful install, confirm `C:\Windows\Temp\dorc-*` is empty on the target.

## Out of scope / follow-ups

- `Invoke-RemoteProcess` has a pre-existing quirk where `$remProcs.Count` is emitted to the output stream inside the child-process-wait loop (`Remove-NSIS*` callers depend on the `[0]` indexing contract to skip over it). Not touched here, but worth cleaning up separately.
- `Invoke-RemoteProcess` itself still has no Pester coverage for the UNC staging / `Copy-Item -ToSession` / `bolResult=$false` paths — would require mocking `New-PSSession`, `Copy-Item`, `Invoke-Command`, and `Remove-PSSession` in concert (~100–150 lines of harness for ~50 lines of code under test). Deferred; the new Pester suite covers the `Find-RemoteNSIS` and `Remove-NSIS*` surfaces which were the direct regression vectors.
- The existing `DOrcDeployModule.tests.ps1` and `DorcDeployModule.unit.tests.ps1` files are not invoked by the new CI step — they haven't been kept running and may have drift. Separate follow-up to re-enable them.
- Self-heal for orphan registry entries (delete the `Uninstall\{...}` key when its `UninstallString` points at a missing file) would let deploys recover from stale state automatically. Would need care to avoid deleting legitimate keys during transient network blips.

