### PR TITLE
Replace DeployMSI blind Start-Sleep with bounded drop-folder wait

### DIFF
--- a/DOrcDeployModule.psm1
+++ b/DOrcDeployModule.psm1
@@ -2242,9 +2242,19 @@ Function DeployMSI {
         [Switch]$NoLogoffUsers
     )
     try {
-    	   Start-Sleep -s 10
+        # Bounded wait for the drop folder / MSI to become available, replacing a
+        # legacy unconditional 'Start-Sleep -s 10'. Returns as soon as the MSI is
+        # found; only waits (up to $DropFolderMaxWaitSeconds) when it isn't yet there.
+        $DropFolderMaxWaitSeconds = 10
+        $DropFolderPollSeconds = 1
+        $DropFolderWaited = 0
+        $msiFiles = @(Get-ChildItem -Path $DropFolder -Include $MSIFile -Recurse -ErrorAction SilentlyContinue)
+        while ($msiFiles.Count -eq 0 -and $DropFolderWaited -lt $DropFolderMaxWaitSeconds) {
+            Start-Sleep -Seconds $DropFolderPollSeconds
+            $DropFolderWaited += $DropFolderPollSeconds
+            $msiFiles = @(Get-ChildItem -Path $DropFolder -Include $MSIFile -Recurse -ErrorAction SilentlyContinue)
+        }
 
-        $msiFiles = Get-ChildItem -Path $DropFolder -Include $MSIFile -Recurse        
         if ($msiFiles.Count -eq 0) {
             throw "[ERROR][DeployMSI][$(Get-Date)] Could not find any files named $($MSIFile) in $DropFolder"
         }


### PR DESCRIPTION
## Summary
Replaces the unconditional `Start-Sleep -s 10` at the top of `DeployMSI` with a **bounded wait** that polls the drop folder for the target MSI, returning as soon as it's found and only waiting (1s intervals, up to 10s) when the file isn't yet present. Removes the fixed ~10s-per-deploy cost in the common case while keeping a safety margin for a slow/unready network share.

## Background
- The sleep has existed since the original module drop (ADO commit `0788099`, Richard Forrester, **2018-02-14**) with **no recorded rationale**. The line was never modified in its 7-year history.
- It ran **once per DeployMSI invocation**, immediately before the recursive drop-folder scan and **before** the parallel `Start-Job` that stops services and runs msiexec.
- It therefore did **not** guard the uninstall, service stop, or file-handle release. Its only plausible original purpose was letting the network drop share settle before `Get-ChildItem` — which is exactly what the bounded poll now handles explicitly.

## Behaviour
- Share ready (normal case): proceeds in ~0s instead of always waiting 10s.
- Share/MSI not yet available: polls every 1s up to 10s, then throws the existing `Could not find any files` error — same failure mode as before, no worse.

## Testing
- `[Parser]::ParseFile` = PARSE OK.
- Recommend confirming across a few DV deploys.

Follow-up to the MSI uninstall performance work in #15.